### PR TITLE
Feature/add buffs warlock

### DIFF
--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -633,10 +633,10 @@ function DataToColor:getBuffsForClass()
     elseif CC == "WARRIOR" then        
         class=class+self:MakeIndexBase2(self:GetBuffs("Battle Shout"), 10);        
     elseif CC == "WARLOCK" then        
-        class=class+self:MakeIndexBase2(self:GetBuffs("Demon Skin"), 10) +
+        class=class+self:MakeIndexBase2(self:GetBuffs("Demon"), 10) +
         self:MakeIndexBase2(self:GetBuffs("Soul Link"), 11) +
         self:MakeIndexBase2(self:GetBuffs("Soulstone Resurrection"), 12) +
-        self:MakeIndexBase2(self:GetBuffs("Demon Armor"), 13);
+        self:MakeIndexBase2(self:GetBuffs("Nightfall"), 13);
     end
     return class;
 end

--- a/Addons/DataToColor/DataToColor.lua
+++ b/Addons/DataToColor/DataToColor.lua
@@ -636,7 +636,7 @@ function DataToColor:getBuffsForClass()
         class=class+self:MakeIndexBase2(self:GetBuffs("Demon"), 10) +
         self:MakeIndexBase2(self:GetBuffs("Soul Link"), 11) +
         self:MakeIndexBase2(self:GetBuffs("Soulstone Resurrection"), 12) +
-        self:MakeIndexBase2(self:GetBuffs("Nightfall"), 13);
+        self:MakeIndexBase2(self:GetBuffs("Shadow Trance"), 13);
     end
     return class;
 end
@@ -725,10 +725,10 @@ function DataToColor:getDebuffsForTarget()
     elseif CC == "WARRIOR" then        
         class=class+self:MakeIndexBase2(self:GetDebuffs("Rend"), 0);
     elseif CC == "WARLOCK" then        
-        class=self:MakeIndexBase2(self:GetDebuffs("Curse of Weakness"), 0) +
-        self:MakeIndexBase2(self:GetDebuffs("Curse of Agony"), 1) +
-        self:MakeIndexBase2(self:GetDebuffs("Corruption"), 2) +
-        self:MakeIndexBase2(self:GetDebuffs("Immolate"), 3);
+        class=self:MakeIndexBase2(self:GetDebuffs("Curse of"), 0) +
+        self:MakeIndexBase2(self:GetDebuffs("Corruption"), 1) +
+        self:MakeIndexBase2(self:GetDebuffs("Immolate"), 2) +
+        self:MakeIndexBase2(self:GetDebuffs("Siphon Life"), 3);
     end
 
     return class;

--- a/Json/class/Warlock_40_Raptor.json
+++ b/Json/class/Warlock_40_Raptor.json
@@ -3,21 +3,21 @@
   "Loot": true,
   "NPCMaxLevels_Above": 2,
 
-  "PathFilename": "17_Redridge.json",
+  "PathFilename": "_p1/38-41 Dust Raptors.json",
   "PathThereAndBack": true,
   "PathReduceSteps": true,
 
-  "Blacklist": ["Murloc Hunter", "Murloc Oracle", "Murloc Tidehunter"],
+  "Mode": "AttendedGrind",
 
   "Pull": {
     "Sequence": [
       {
         "Name": "pull",
-        "Key": "5",
+        "Key": "2",
         "HasCastBar": true,
         "StopBeforeCast": true,
         "ResetOnNewTarget": true,
-        "MinMana": 90,
+        "MinMana": 220,
         "Log": false
       }
     ]
@@ -25,77 +25,77 @@
   "Combat": {
     "Sequence": [
       {
-        "Name": "heal",
-        "Key": "N3",
-        "Requirements": ["Health%<50", "BagItem:19005:1"],
-        "Cooldown": 120,
-        "InCombat": "true",
+        "Name": "Healthstone",
+        "Key": "F6",
+        "Requirement": "Health%<45",
+        "Cooldown": 60,
         "Log": false
       },
       {
         "Name": "Drain Soul",
-        "Key": "9",
+        "Key": "6",
         "HasCastBar": true,
         "StopBeforeCast": true,
-        "Requirements": ["TargetHealth%<25", "not BagItem:6265:3"],
+        "Requirements": [ "TargetHealth%<30", "not BagItem:6265:5" ],
         "MinMana": 55
       },
       {
         "Name": "Drain Life",
-        "Key": "N4",
+        "Key": "8",
         "HasCastBar": true,
         "StopBeforeCast": true,
-        "Requirements": ["Health%<30"],
-        "MinMana": 55
+        "Requirements": [ "Health%<60", "TargetHealth%>20" ],
+        "MinMana": 185
       },
       {
-        "Name": "Immolate",
-        "Key": "5",
-        "Requirements": ["TargetHealth%>35", "not Immolate"],
-        "HasCastBar": true,
-        "StopBeforeCast": true,
-        "ResetOnNewTarget": true,
-        "MinMana": 90,
+        "Name": "Amplify Curse",
+        "Key": "0",
+        "Cooldown": 180,
+        "MinMana": 0,
         "Log": false
       },
       {
         "Name": "Curse of Agony",
-        "Key": "1",
+        "Key": "4",
         "ResetOnNewTarget": true,
-        "Requirements": [ "TargetHealth%>35", "not Curse of Agony"],
-        "MinMana": 50,
+        "Requirements": [ "TargetHealth%>80", "not Curse of" ],
+        "MinMana": 130,
+        "Log": false
+      },
+      {
+        "Name": "Siphon Life",
+        "Key": "5",
+        "Requirements": [ "TargetHealth%>45", "not Siphon Life" ],
+        "ResetOnNewTarget": true,
+        "MinMana": 150,
         "Log": false
       },
       {
         "Name": "Corruption",
-        "Key": "7",
-        "Requirements": ["TargetHealth%>35", "not Corruption"],
+        "Key": "3",
+        "Requirements": [ "TargetHealth%>45", "not Corruption" ],
         "ResetOnNewTarget": true,
-        "MinMana": 55,
+        "MinMana": 160,
         "Log": false
       },
       {
         "Name": "Shadow Bolt",
-        "Key": "2",
-        "HasCastBar": true,
-        "StopBeforeCast": true,
-        "ResetOnNewTarget": true,
-        "MinMana": 110,
-        "Requirement": "TargetHealth%>35",
-        "Log": false,
-        "Cooldown": 8
+        "Key": "1",
+        "MinMana": 210,
+        "Requirements": [ "Shadow Trance" ],
+        "Log": false
+      },
+      {
+        "Name": "shoot",
+        "Key": "7",
+        "Cooldown": 10,
+        "Requirements": [ "HasRangedWeapon", "not Shooting" ],
+        "Log": false
       },
       {
         "Name": "Interact",
         "Key": "H",
         "Cooldown": 3,
-        "Log": false
-      },
-      {
-        "Name": "shoot",
-        "Key": "0",
-        "Cooldown": 3,
-        "Requirements": ["HasRangedWeapon", "not Shooting"],
         "Log": false
       }
     ]
@@ -106,7 +106,7 @@
         "Name": "Food",
         "StopBeforeCast": true,
         "Key": "N1",
-        "Requirement": "Health%<50",
+        "Requirement": "Health%<10",
         "Cooldown": 20,
         "Log": false
       },
@@ -114,72 +114,85 @@
         "Name": "Water",
         "StopBeforeCast": true,
         "Key": "N2",
-        "Requirement": "Mana%<50",
+        "Requirement": "Mana%<10",
         "Cooldown": 20,
         "Log": false
       }
     ]
-    },
+  },
   "Adhoc": {
     "Sequence": [
       {
-        "Name": "Demon Skin",
-        "Key": "3",
-        "MinMana": 50,
-        "Requirement": "not Demon Skin",
+        "Name": "Demon Armor",
+        "Key": "=",
+        "MinMana": 800,
+        "Requirement": "not Demon Armor",
         "Log": false
       },
       {
-        "Name": "Summon Voidwalker",
+        "Name": "Summon Succubus",
         "HasCastBar": true,
         "StopBeforeCast": true,
-        "Key": "4",
-        "MinMana": 122,
-        "Requirements": ["BagItem:6265:1", "not Has Pet"],
+        "Key": "F9",
+        "MinMana": 923,
+        "Requirements": [ "BagItem:6265:1", "not Has Pet" ],
         "Log": false,
-        "Cooldown": 60
+        "Cooldown": 10
       },
       {
         "Name": "Life Tap",
-        "StopBeforeCast": true,
-        "Key": "8",
-        "Requirements": ["Health%>70","Mana%<60"],
+        "Key": "9",
+        "Requirements": [ "Health%>60", "Mana%<60" ],
         "Cooldown": 0,
         "Log": false
       },
       {
-        "Name": "Life Tap 2",
-        "StopBeforeCast": true,
-        "Key": "8",
-        "Requirements": ["Health%>80","Mana%<80"],
+        "Name": "Dark Pact",
+        "Key": "F3",
+        "Requirements": [ "Mana%<45", "Has Pet" ],
         "Cooldown": 0,
         "Log": false
       },
       {
-        "Name": "heal",
-        "Key": "N3",
-        "HasCastBar": true,
-        "Requirements": ["BagItem:6265:1", "not BagItem:19005:1"]
+        "Name": "Create Soulstone",
+        "Key": "F11",
+        "Requirements": [ "not BagItem:16893:1", "BagItem:6265:1" ],
+        "Cooldown": 0,
+        "Log": false
+      },
+      {
+        "Name": "Apply Soulstone",
+        "Key": "F12",
+        "Requirements": [ "BagItem:16893:1", "not Soulstone Resurrection" ],
+        "Cooldown": 1800,
+        "Log": false
+      },
+      {
+        "Name": "Create HealthStone",
+        "Key": "F5",
+        "Requirements": [ "not BagItem:5509:1", "BagItem:6265:1" ],
+        "Cooldown": 0,
+        "Log": false
+      }
+
+    ]
+  },
+  "NPC": {
+    "Sequence": [
+      {
+        "Name": "Repair",
+        "Key": "C",
+        "Requirement": "Items Broken",
+        "PathFilename": "23_Duskwood_Vendor.json",
+        "Cost": 6
+      },
+      {
+        "Name": "Sell",
+        "Key": "C",
+        "Requirement": "BagFull",
+        "PathFilename": "23_Duskwood_Vendor.json",
+        "Cost": 6
       }
     ]
-  }
-,
-  "NPC": {
-      "Sequence": [
-        {
-          "Name": "Repair",
-          "Key": "C",
-          "Requirement": "Items Broken",
-          "PathFilename": "23_Duskwood_Vendor.json",
-          "Cost": 6
-        },
-        {
-          "Name": "Sell",
-          "Key": "C",
-          "Requirement": "BagFull",
-          "PathFilename": "23_Duskwood_Vendor.json",
-          "Cost": 6
-        }
-      ]
   }
 }

--- a/Json/class/Warlock_40_Raptor.json
+++ b/Json/class/Warlock_40_Raptor.json
@@ -1,0 +1,185 @@
+{
+  "ClassName": "Warlock",
+  "Loot": true,
+  "NPCMaxLevels_Above": 2,
+
+  "PathFilename": "17_Redridge.json",
+  "PathThereAndBack": true,
+  "PathReduceSteps": true,
+
+  "Blacklist": ["Murloc Hunter", "Murloc Oracle", "Murloc Tidehunter"],
+
+  "Pull": {
+    "Sequence": [
+      {
+        "Name": "pull",
+        "Key": "5",
+        "HasCastBar": true,
+        "StopBeforeCast": true,
+        "ResetOnNewTarget": true,
+        "MinMana": 90,
+        "Log": false
+      }
+    ]
+  },
+  "Combat": {
+    "Sequence": [
+      {
+        "Name": "heal",
+        "Key": "N3",
+        "Requirements": ["Health%<50", "BagItem:19005:1"],
+        "Cooldown": 120,
+        "InCombat": "true",
+        "Log": false
+      },
+      {
+        "Name": "Drain Soul",
+        "Key": "9",
+        "HasCastBar": true,
+        "StopBeforeCast": true,
+        "Requirements": ["TargetHealth%<25", "not BagItem:6265:3"],
+        "MinMana": 55
+      },
+      {
+        "Name": "Drain Life",
+        "Key": "N4",
+        "HasCastBar": true,
+        "StopBeforeCast": true,
+        "Requirements": ["Health%<30"],
+        "MinMana": 55
+      },
+      {
+        "Name": "Immolate",
+        "Key": "5",
+        "Requirements": ["TargetHealth%>35", "not Immolate"],
+        "HasCastBar": true,
+        "StopBeforeCast": true,
+        "ResetOnNewTarget": true,
+        "MinMana": 90,
+        "Log": false
+      },
+      {
+        "Name": "Curse of Agony",
+        "Key": "1",
+        "ResetOnNewTarget": true,
+        "Requirements": [ "TargetHealth%>35", "not Curse of Agony"],
+        "MinMana": 50,
+        "Log": false
+      },
+      {
+        "Name": "Corruption",
+        "Key": "7",
+        "Requirements": ["TargetHealth%>35", "not Corruption"],
+        "ResetOnNewTarget": true,
+        "MinMana": 55,
+        "Log": false
+      },
+      {
+        "Name": "Shadow Bolt",
+        "Key": "2",
+        "HasCastBar": true,
+        "StopBeforeCast": true,
+        "ResetOnNewTarget": true,
+        "MinMana": 110,
+        "Requirement": "TargetHealth%>35",
+        "Log": false,
+        "Cooldown": 8
+      },
+      {
+        "Name": "Interact",
+        "Key": "H",
+        "Cooldown": 3,
+        "Log": false
+      },
+      {
+        "Name": "shoot",
+        "Key": "0",
+        "Cooldown": 3,
+        "Requirements": ["HasRangedWeapon", "not Shooting"],
+        "Log": false
+      }
+    ]
+  },
+  "Parallel": {
+    "Sequence": [
+      {
+        "Name": "Food",
+        "StopBeforeCast": true,
+        "Key": "N1",
+        "Requirement": "Health%<50",
+        "Cooldown": 20,
+        "Log": false
+      },
+      {
+        "Name": "Water",
+        "StopBeforeCast": true,
+        "Key": "N2",
+        "Requirement": "Mana%<50",
+        "Cooldown": 20,
+        "Log": false
+      }
+    ]
+    },
+  "Adhoc": {
+    "Sequence": [
+      {
+        "Name": "Demon Skin",
+        "Key": "3",
+        "MinMana": 50,
+        "Requirement": "not Demon Skin",
+        "Log": false
+      },
+      {
+        "Name": "Summon Voidwalker",
+        "HasCastBar": true,
+        "StopBeforeCast": true,
+        "Key": "4",
+        "MinMana": 122,
+        "Requirements": ["BagItem:6265:1", "not Has Pet"],
+        "Log": false,
+        "Cooldown": 60
+      },
+      {
+        "Name": "Life Tap",
+        "StopBeforeCast": true,
+        "Key": "8",
+        "Requirements": ["Health%>70","Mana%<60"],
+        "Cooldown": 0,
+        "Log": false
+      },
+      {
+        "Name": "Life Tap 2",
+        "StopBeforeCast": true,
+        "Key": "8",
+        "Requirements": ["Health%>80","Mana%<80"],
+        "Cooldown": 0,
+        "Log": false
+      },
+      {
+        "Name": "heal",
+        "Key": "N3",
+        "HasCastBar": true,
+        "Requirements": ["BagItem:6265:1", "not BagItem:19005:1"]
+      }
+    ]
+  }
+,
+  "NPC": {
+      "Sequence": [
+        {
+          "Name": "Repair",
+          "Key": "C",
+          "Requirement": "Items Broken",
+          "PathFilename": "23_Duskwood_Vendor.json",
+          "Cost": 6
+        },
+        {
+          "Name": "Sell",
+          "Key": "C",
+          "Requirement": "BagFull",
+          "PathFilename": "23_Duskwood_Vendor.json",
+          "Cost": 6
+        }
+      ]
+  }
+}

--- a/Libs/Addon/BuffStatus.cs
+++ b/Libs/Addon/BuffStatus.cs
@@ -29,24 +29,12 @@
         public bool WellFed { get => IsBitSet(2); }
         public bool ManaRegeneration { get => IsBitSet(3); }
 
-        // Priest
-        public bool Fortitude { get => IsBitSet(10); }
-
-        public bool InnerFire { get => IsBitSet(11); }
-        public bool Renew { get => IsBitSet(12); }
-        public bool Shield { get => IsBitSet(13); }
-        public bool DivineSpirit { get => IsBitSet(14); }
-
         // Druid
         public bool MarkOfTheWild { get => IsBitSet(10); }
         public bool Thorns { get => IsBitSet(11); }
         public bool TigersFury { get => IsBitSet(12); }
 
-        // Paladin
-        public bool Aura { get => IsBitSet(10); }
-
-        public bool Blessing { get => IsBitSet(11); }
-        public bool Seal { get => IsBitSet(12); }
+        // Hunter
 
         // Mage
         public bool FrostArmor { get => IsBitSet(10); }
@@ -56,8 +44,23 @@
         public bool Ward { get => IsBitSet(13); }
         public bool FirePower { get => IsBitSet(14); }
 
+        // Paladin
+        public bool Aura { get => IsBitSet(10); }
+
+        public bool Blessing { get => IsBitSet(11); }
+        public bool Seal { get => IsBitSet(12); }
+
+        // Priest
+        public bool Fortitude { get => IsBitSet(10); }
+        public bool InnerFire { get => IsBitSet(11); }
+        public bool Renew { get => IsBitSet(12); }
+        public bool Shield { get => IsBitSet(13); }
+        public bool DivineSpirit { get => IsBitSet(14); }
+
         // Rogue
         public bool SliceAndDice { get => IsBitSet(10); }
+
+        // Shaman
 
         // Warrior
         public bool BattleShout { get => IsBitSet(10); }

--- a/Libs/Addon/BuffStatus.cs
+++ b/Libs/Addon/BuffStatus.cs
@@ -63,9 +63,9 @@
         public bool BattleShout { get => IsBitSet(10); }
 
         // Warlock
-        public bool DemonSkin { get => IsBitSet(10); }
+        public bool DemonArmor { get => IsBitSet(10); }
         public bool SoulLink { get => IsBitSet(11); }
         public bool SoulstoneResurrection { get => IsBitSet(12); }
-        public bool DemonArmor { get => IsBitSet(13); }
+        public bool Nightfall { get => IsBitSet(13); }
     }
 }

--- a/Libs/Addon/BuffStatus.cs
+++ b/Libs/Addon/BuffStatus.cs
@@ -66,6 +66,6 @@
         public bool DemonArmor { get => IsBitSet(10); }
         public bool SoulLink { get => IsBitSet(11); }
         public bool SoulstoneResurrection { get => IsBitSet(12); }
-        public bool Nightfall { get => IsBitSet(13); }
+        public bool ShadowTrance { get => IsBitSet(13); }
     }
 }

--- a/Libs/Addon/DeBuffStatus.cs
+++ b/Libs/Addon/DeBuffStatus.cs
@@ -21,29 +21,34 @@
         }
 
         public string name { get; set; } = string.Empty;
-
-        // Priest
-        public bool ShadowWordPain { get => IsBitSet(0); }
+        // All
 
         // Druid
         public bool Roar { get => IsBitSet(0); }
         public bool FaerieFire { get => IsBitSet(1); }
         public bool Rip { get => IsBitSet(2); }
 
-        // Paladin
+        // Hunter
 
         // Mage
         public bool Frostbite { get => IsBitSet(0); }
 
-        // Rogue
+        // Paladin
 
-        // Warrior
-        public bool Rend { get => IsBitSet(0); }
+        // Priest
+        public bool ShadowWordPain { get => IsBitSet(0); }
+
+        // Rogue
 
         // Warlock
         public bool CurseOf { get => IsBitSet(0); }
         public bool Corruption { get => IsBitSet(1); }
         public bool Immolate { get => IsBitSet(2); }
         public bool SiphonLife { get => IsBitSet(3); }
+
+        // Warrior
+        public bool Rend { get => IsBitSet(0); }
+
+
     }
 }

--- a/Libs/Addon/DeBuffStatus.cs
+++ b/Libs/Addon/DeBuffStatus.cs
@@ -41,9 +41,9 @@
         public bool Rend { get => IsBitSet(0); }
 
         // Warlock
-        public bool CurseofWeakness { get => IsBitSet(0); }
-        public bool CurseofAgony { get => IsBitSet(1); }
-        public bool Corruption { get => IsBitSet(2); }
-        public bool Immolate { get => IsBitSet(3); }
+        public bool CurseOf { get => IsBitSet(0); }
+        public bool Corruption { get => IsBitSet(1); }
+        public bool Immolate { get => IsBitSet(2); }
+        public bool SiphonLife { get => IsBitSet(3); }
     }
 }

--- a/Libs/Requirement/RequirementFactory.cs
+++ b/Libs/Requirement/RequirementFactory.cs
@@ -114,10 +114,10 @@ namespace Libs
                     {  "Fire Power", ()=>playerReader.Buffs.FirePower },
                     {  "Slice And Dice", ()=> playerReader.Buffs.SliceAndDice },
                     {  "Battle Shout", ()=> playerReader.Buffs.BattleShout },
-                    {  "Demon Skin", ()=> playerReader.Buffs.DemonSkin },
                     {  "Demon Armor", ()=> playerReader.Buffs.DemonArmor },
                     {  "Soul Link", ()=> playerReader.Buffs.SoulLink },
                     {  "Soulstone Resurrection", ()=> playerReader.Buffs.SoulstoneResurrection },
+                    {  "Nightfall", ()=> playerReader.Buffs.Nightfall },
                     {  "Has Pet", ()=> playerReader.PlayerBitValues.HasPet },
 
                     {  "Demoralizing Roar", ()=> playerReader.Debuffs.Roar },

--- a/Libs/Requirement/RequirementFactory.cs
+++ b/Libs/Requirement/RequirementFactory.cs
@@ -117,7 +117,7 @@ namespace Libs
                     {  "Demon Armor", ()=> playerReader.Buffs.DemonArmor },
                     {  "Soul Link", ()=> playerReader.Buffs.SoulLink },
                     {  "Soulstone Resurrection", ()=> playerReader.Buffs.SoulstoneResurrection },
-                    {  "Nightfall", ()=> playerReader.Buffs.Nightfall },
+                    {  "Shadow Trance", ()=> playerReader.Buffs.ShadowTrance },
                     {  "Has Pet", ()=> playerReader.PlayerBitValues.HasPet },
 
                     {  "Demoralizing Roar", ()=> playerReader.Debuffs.Roar },
@@ -127,10 +127,10 @@ namespace Libs
 
                     {  "Shadow Word: Pain", ()=> playerReader.Debuffs.ShadowWordPain },
 
-                    {  "Curse of Weakness", ()=> playerReader.Debuffs.CurseofWeakness },
-                    {  "Curse of Agony", ()=> playerReader.Debuffs.CurseofAgony },
+                    {  "Curse of", ()=> playerReader.Debuffs.CurseOf },
                     {  "Corruption", ()=> playerReader.Debuffs.Corruption },
                     {  "Immolate", ()=> playerReader.Debuffs.Immolate },
+                    {  "Siphon Life", ()=> playerReader.Debuffs.SiphonLife },
 
 
                     { "OutOfCombatRange", ()=> !playerReader.WithInCombatRange },

--- a/Libs/Requirement/RequirementFactory.cs
+++ b/Libs/Requirement/RequirementFactory.cs
@@ -90,54 +90,85 @@ namespace Libs
             {
                 BuffDictionary = new Dictionary<string, Func<bool>>
                 {
-                    {  "Seal", ()=> playerReader.Buffs.Seal },
-                    {  "Aura", ()=>playerReader.Buffs.Aura },
-                    {  "Devotion Aura", ()=>playerReader.Buffs.Aura },
-                    {  "Blessing", ()=> playerReader.Buffs.Blessing },
-                    {  "Blessing of Might", ()=> playerReader.Buffs.Blessing },
+                    // All
                     {  "Well Fed", ()=> playerReader.Buffs.WellFed },
                     {  "Eating", ()=> playerReader.Buffs.Eating },
                     {  "Drinking", ()=> playerReader.Buffs.Drinking },
                     {  "Mana Regeneration", ()=> playerReader.Buffs.ManaRegeneration },
-                    {  "Fortitude", ()=> playerReader.Buffs.Fortitude },
-                    {  "InnerFire", ()=> playerReader.Buffs.InnerFire },
-                    {  "Divine Spirit", ()=> playerReader.Buffs.DivineSpirit },
-                    {  "Renew", ()=> playerReader.Buffs.Renew },
-                    {  "Shield", ()=> playerReader.Buffs.Shield },
+                    //-------------------------
+
+
+                    // Druid
                     {  "Mark of the Wild", ()=> playerReader.Buffs.MarkOfTheWild },
                     {  "Thorns", ()=> playerReader.Buffs.Thorns },
                     {  "TigersFury", ()=> playerReader.Buffs.TigersFury },
+                    //-------------------------
+                    {  "Demoralizing Roar", ()=> playerReader.Debuffs.Roar },
+                    {  "Faerie Fire", ()=> playerReader.Debuffs.FaerieFire },
+                    {  "Rip", ()=> playerReader.Debuffs.Rip },
+
+                    // Hunter
+
+                    //-------------------------
+
+                    // Mage
                     {  "Frost Armor", ()=> playerReader.Buffs.FrostArmor },
                     {  "Arcane Intellect", ()=> playerReader.Buffs.ArcaneIntellect },
                     {  "Ice Barrier", ()=>playerReader.Buffs.IceBarrier },
                     {  "Ward", ()=>playerReader.Buffs.Ward },
                     {  "Fire Power", ()=>playerReader.Buffs.FirePower },
+                    //-------------------------
+                    {  "Frostbite", ()=> playerReader.Debuffs.Rip },
+
+                    //  Paladin
+                    {  "Seal", ()=> playerReader.Buffs.Seal },
+                    {  "Aura", ()=>playerReader.Buffs.Aura },
+                    {  "Devotion Aura", ()=>playerReader.Buffs.Aura },
+                    {  "Blessing", ()=> playerReader.Buffs.Blessing },
+                    {  "Blessing of Might", ()=> playerReader.Buffs.Blessing },
+                    //-------------------------
+
+                    // Priest
+                    {  "Fortitude", ()=> playerReader.Buffs.Fortitude },
+                    {  "InnerFire", ()=> playerReader.Buffs.InnerFire },
+                    {  "Divine Spirit", ()=> playerReader.Buffs.DivineSpirit },
+                    {  "Renew", ()=> playerReader.Buffs.Renew },
+                    {  "Shield", ()=> playerReader.Buffs.Shield },
+                    //-------------------------
+                    {  "Shadow Word: Pain", ()=> playerReader.Debuffs.ShadowWordPain },
+
+                    // Rogue
                     {  "Slice And Dice", ()=> playerReader.Buffs.SliceAndDice },
-                    {  "Battle Shout", ()=> playerReader.Buffs.BattleShout },
+                    //-------------------------
+
+                    // Shaman
+                    
+                    //-------------------------
+
+                    // Warlock
                     {  "Demon Armor", ()=> playerReader.Buffs.DemonArmor },
                     {  "Soul Link", ()=> playerReader.Buffs.SoulLink },
                     {  "Soulstone Resurrection", ()=> playerReader.Buffs.SoulstoneResurrection },
                     {  "Shadow Trance", ()=> playerReader.Buffs.ShadowTrance },
-                    {  "Has Pet", ()=> playerReader.PlayerBitValues.HasPet },
-
-                    {  "Demoralizing Roar", ()=> playerReader.Debuffs.Roar },
-                    {  "Faerie Fire", ()=> playerReader.Debuffs.FaerieFire },
-                    {  "Rip", ()=> playerReader.Debuffs.Rip },
-                    {  "Rend", ()=> playerReader.Debuffs.Rend },
-
-                    {  "Shadow Word: Pain", ()=> playerReader.Debuffs.ShadowWordPain },
-
+                    //-------------------------
                     {  "Curse of", ()=> playerReader.Debuffs.CurseOf },
                     {  "Corruption", ()=> playerReader.Debuffs.Corruption },
                     {  "Immolate", ()=> playerReader.Debuffs.Immolate },
                     {  "Siphon Life", ()=> playerReader.Debuffs.SiphonLife },
+                    
+                    // Warrior
+                    {  "Battle Shout", ()=> playerReader.Buffs.BattleShout },
+                    //-------------------------
+                    {  "Rend", ()=> playerReader.Debuffs.Rend },
 
 
+
+
+                    //CONDITIONALS
+                    { "Has Pet", ()=> playerReader.PlayerBitValues.HasPet },
                     { "OutOfCombatRange", ()=> !playerReader.WithInCombatRange },
                     { "InCombatRange", ()=> playerReader.WithInCombatRange },
-
                     { "InFireblastRange", ()=> playerReader.SpellInRange.Mage_Fireblast },
-
                     { "AutoAttacking", ()=> playerReader.IsAutoAttacking },
                     { "Shooting", ()=> playerReader.IsShooting },
                     { "Items Broken", ()=> playerReader.PlayerBitValues.ItemsAreBroken },

--- a/README.md
+++ b/README.md
@@ -401,41 +401,52 @@ e.g.
 
 | Class | Buff |
 | --- | --- |
-| All | "Items Broken" |
-| All | "HasRangedWeapon" |
 | All | "Well Fed" |
 | All | "Eating" |
 | All | "Drinking" |
 | All | "Mana Regeneration" |
+| All | CONDITIONALS |
+| All | "Items Broken" |
+| All | "HasRangedWeapon" |
 | All | "OutOfCombatRange" |
 | All | "InCombatRange" |
 | All | "AutoAttacking" |
 | All | "Shooting" |
+| All | "Has Pet" |
+| Druid | "Mark of the Wild" |
+| Druid | "Thorns" |
+| Druid | "TigersFury" |
+| Mage | "Frost Armor" |
+| Mage | "Arcane Intellect" |
+| Mage | "Ice Barrier" |
+| Mage | "Ward" |
+| Mage | "Fire Power" |
+| Paladin | "Seal" |
+| Paladin |  "Aura" |
+| Paladin |  "Blessing" |
 | Priest | "Fortitude" |
 | Priest | "InnerFire" |
 | Priest | "Divine Spirit" |
 | Priest | "Renew" |
 | Priest | "Shield" |
-| Priest | "Shadow Word: Pain" |
-| Paladin | "Seal" |
-| Paladin |  "Aura" |
-| Paladin |  "Blessing" |
-| Druid | "Mark of the Wild" |
-| Druid | "Thorns" |
-| Druid Debuff | "Demoralizing Roar"
-| Druid Debuff | "Faerie Fire"
-| Mage | "Frost Armor" |
-| Mage | "Arcane Intellect" |
-| Mage | "Ice Barrier" |
 | Rogue | "Slice And Dice" |
+| Warlock | "Demon Armor"  |
+| Warlock | "Shadow Trance" |
+| Warlock | "Soulstone Resurraction" |
+| Warlock | "Soul Link" |
 | Warrior | "Battle Shout" |
-| Warlock | "Demon Skin" |
-| Warlock | "Has Pet" |
-| Warlock | "Curse of Weakness" |
-| Warlock | "Curse of Agony" |
+
+| Class | Debuff |
+| --- | --- |
+| Druid | "Demoralizing Roar" |
+| Druid | "Faerie Fire" |
+| Mage | "Frostbite" |
+| Priest | "Shadow Word: Pain" |
+| Warlock | "Curse of" |
+| Warlock | "Siphon Life" |
 | Warlock | "Corruption" |
 | Warlock | "Immolate" |
-| Warrior Debuff | "Rend" |
+| Warrior | "Rend" |
  
 #### Range
 


### PR DESCRIPTION
Updated the warlock de/buffs to include shadow trance and siphon life. Also changed the search string for warlock curse and armor buff search string. This will allow "demon" and "curse of" strings to search for many buffs without making one for each.

Added a level 40 warlock class configuration used to test the changes. NPC portion is incorrect.

Cleaned up the Buff Factory, Buff and Debuff files to be read easier. 

Updated the read me with current class de/buff conditionals.